### PR TITLE
Adaptions for Obspy 1.0 and declaration of maximal version numbers of twisted and zope.interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
-# We pretend to be erlang because we can't use the python support in travis-ci
-# see also: https://groups.google.com/forum/#!msg/travis-ci/uJgu35XKdmI/CctnUkYnEJEJ
-language: erlang
+language: python
+python:
+  - "2.7"
+sudo: false
 before_install:
-  - lsb_release -a
-  - sudo apt-get install -qq gfortran python python-dev python-setuptools python-numpy python-scipy python-matplotlib python-suds python-lxml python-sqlalchemy 1> /dev/null # install dependencies
-  - sudo easy_install https://github.com/obspy/obspy/archive/master.zip
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"  
+  - hash -r
+  - conda config --set always_yes yes
+  - conda update -q conda
+  - conda info -a
+  - conda config --add channels obspy
+  - conda install "obspy<1.1" "twisted<16" "zope.interface<4.1" cheetah "sqlalchemy<0.8" pyopenssl lxml pycrypto pyasn1 pyparsing
 install:
-  - sudo python setup.py -q install
+  - pip install --no-deps .
 script:
-  - sudo seishub-runtests
+  - mkdir empty; cd empty
+  - seishub-runtests
 notifications:
     email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 SQLAlchemy >0.7.7, <0.8
 Cheetah
 pycrypto
-Twisted
+Twisted<16
+zope.interface<4.1
 pyparsing
 pyasn1
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pyparsing
 pyasn1
 lxml
 pyOpenSSL
-obspy <0.10.0
+obspy
 psycopg2

--- a/seishub/core/processor/tests/test_rest_property.py
+++ b/seishub/core/processor/tests/test_rest_property.py
@@ -5,7 +5,6 @@ A test suite for B{GET} request on REST resources.
 
 from StringIO import StringIO
 from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util.decorator import skipIf
 from seishub.core.core import Component, implements
 from seishub.core.packages.builtins import IResourceType, IPackage
 from seishub.core.packages.installer import registerIndex
@@ -422,7 +421,8 @@ class RestPropertyTests(SeisHubEnvironmentTestCase):
         self.assertTrue("<value>1970-12-20 12:13:00</value>" in data)
         proc.run(DELETE, '/property-test/notvc2/1')
 
-    @skipIf(NO_NEGATIVE_TIMESTAMPS, 'times before 1970 are not supported')
+    @unittest.skipIf(NO_NEGATIVE_TIMESTAMPS,
+                     'times before 1970 are not supported')
     def test_validDateTimeIndexesBefore1970(self):
         """
         Test indexing of XML documents with valid datetime fields.

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'pycrypto',
         'pyasn1',
         'pyparsing',
-        'obspy<0.10.0',
+        'obspy<1.1',
     ],
     download_url="https://github.com/barsch/seishub.core/zipball/master" + \
         "#egg=seishub.core-dev",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'Twisted',
+        'Twisted<16', 'zope.interface<4.1',
         'Cheetah',
         'sqlalchemy>0.7.7,<0.8',
         'PyOpenSSL',


### PR DESCRIPTION
Follow up of #13.

I added the dependencies in setup.py and requirements.txt.
For me seishub is also working for a recent obspy, but I can only confirm this for the wavefrom plugin I use. I also tried to update travis.yml.
